### PR TITLE
uplift ice config settings to the case of stunner-gateway-operator

### DIFF
--- a/kurento-magic-mirror/Dockerfile
+++ b/kurento-magic-mirror/Dockerfile
@@ -1,7 +1,7 @@
 # docker build -t l7mp/kurento-magic-mirror .
 # docker push l7mp/kurento-magic-mirror
 
-FROM node:14-alpine3.12
+FROM node:16-alpine3.15
 
 RUN apk update && \
     apk upgrade && \

--- a/kurento-magic-mirror/package.json
+++ b/kurento-magic-mirror/package.json
@@ -6,7 +6,7 @@
     "postinstall": "cd static && bower install"
   },
   "dependencies": {
-    "@l7mp/stunner-auth-lib": "^0.9.3",
+    "@l7mp/stunner-auth-lib": "^0.9.4",
     "cookie-parser": "^1.3.5",
     "express": "^4.17.0",
     "express-session": "^1.17.0",

--- a/kurento-magic-mirror/server.js
+++ b/kurento-magic-mirror/server.js
@@ -28,22 +28,32 @@ var http = require('http');
 var https = require('https');
 
 /* Stunner demo patch starts */
-const StunnerAuth = require('@l7mp/stunner-auth-lib');
-var iceConfiguration = StunnerAuth.getIceConfig();
+const auth = require('@l7mp/stunner-auth-lib');
 
 // patch index.js to statically serve the correct TURN configuration to the clients
 var client_file = 'static/js/index.js';
-file_desc = fs.readFile(client_file, 'utf-8', function(err,data) {
-    if (err) {
-        return console.log(err);
-    }
-    data = data.replace("XXXXXX", JSON.stringify(iceConfiguration));
-    fs.writeFile(client_file, data, 'utf-8', function(err) {
+
+// periodic update of index.js
+function checkIceConfigurationWithDelay(){
+    let iceConfiguration = auth.getIceConfig();
+
+    file_desc = fs.readFile(client_file, 'utf-8', function(err,data) {
         if (err) {
             return console.log(err);
         }
+        if (iceConfiguration){
+            data = data.replace("XXXXXX", JSON.stringify(iceConfiguration));
+            fs.writeFile(client_file, data, 'utf-8', function(err) {
+                if (err) {
+                    return console.log(err);
+                }
+            });
+            console.log("Stunner public IP found: ", JSON.stringify(iceConfiguration));
+        }
     });
-});
+}
+
+setInterval(checkIceConfigurationWithDelay, 5000);
 /* Stunner demo patch ends */
 
 var argv = minimist(process.argv.slice(2), {


### PR DESCRIPTION
Contains the necessary changes for running magic-mirror with the stunner-gateway-operator.  Although it breaks the demo with standalone mode, I do not think that we shall maintain both versions without major reasons.