### PR TITLE
remove re-using of existing kurento connection

### DIFF
--- a/kurento-magic-mirror/server.js
+++ b/kurento-magic-mirror/server.js
@@ -194,10 +194,6 @@ wss.on('connection', function(ws, req) {
 
 // Recover kurentoClient for the first time.
 function getKurentoClient(callback) {
-    if (kurentoClient !== null) {
-        return callback(null, kurentoClient);
-    }
-
     kurento(argv.ws_uri, function(error, _kurentoClient) {
         if (error) {
             console.log("Could not find media server at address " + argv.ws_uri);


### PR DESCRIPTION
Otherwise the server always uses the same kurento media server and
we cannot load-balance across different instances.